### PR TITLE
Bump typing-extensions through new databind

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
     - run:
         name: Install dependencies
         command: |
-          pip install -e '.[dev]'
+          pip install -e '.[farconf-dev]'
     # Run the most informative steps first, even if they're longer
     - run:
         name: Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ maintainers = [
 classifiers = []
 
 dependencies = [
-    "databind @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi",
+    "databind @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind",
+    "databind-core @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind.core",
+    "databind-json @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind.json",
     "typeapi >=2.0.1, <3",
     "PyYAML >= 6.0.1, <7"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,13 @@ maintainers = [
 classifiers = []
 
 dependencies = [
-    "databind @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind",
-    "databind-core @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind.core",
-    "databind-json @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi#subdirectory=databind.json",
+    "databind >=4.5.0, <4.6",
     "typeapi >=2.0.1, <3",
     "PyYAML >= 6.0.1, <7"
 ]
 
 [project.optional-dependencies]
-dev = [
+farconf-dev = [
     "ruff ~=0.1.13",
     "pre-commit ~=3.6.0",
     "pyright ~=1.1.350",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ maintainers = [
 classifiers = []
 
 dependencies = [
-    "databind ~=4.4.2",
-    "typeapi >=2, <3",
-    "PyYAML ~= 6.0.1"
+    "databind @ git+https://github.com/rhaps0dy/python-databind@bump-typeapi",
+    "typeapi >=2.0.1, <3",
+    "PyYAML >= 6.0.1, <7"
 ]
 
 [project.optional-dependencies]
@@ -28,7 +28,7 @@ dev = [
     "ruff ~=0.1.13",
     "pre-commit ~=3.6.0",
     "pyright ~=1.1.350",
-    "pytest ~=8.0.0",
+    "pytest ~=8.1.1",
     "pytest-cov ~=4.1.0",
 ]
 


### PR DESCRIPTION
`typing-extensions<4.7` from databind was holding back an upgrade to latest Pytorch. This is now fixed in a temporary branch and I'm propagating it.