### PR TITLE
Write out full lists when generating a CLI from object updates

### DIFF
--- a/farconf/cli.py
+++ b/farconf/cli.py
@@ -150,7 +150,7 @@ def _sequence_is_leaf_if_different(c_from: Any, c_to: Any) -> bool:
     the diff for two identical lists is `c_to`. This case does not arise when using `update_fns_to_cli`, but we test for
     it anyways in `tests/test_cli.py::test_update_list_nothing`
     """
-    return (c_from != c_to) and isinstance(c_to, Sequence)
+    return isinstance(c_to, Sequence) and (c_from != c_to)
 
 
 if TYPE_CHECKING:

--- a/tests/integration/class_defs.py
+++ b/tests/integration/class_defs.py
@@ -38,3 +38,8 @@ class OneMaybe(OneGeneric):
 @dataclasses.dataclass
 class NonAbstractDataclass:
     a: int
+
+
+@dataclasses.dataclass
+class ClassWithList:
+    a: list[int]

--- a/tests/integration/instances.py
+++ b/tests/integration/instances.py
@@ -1,4 +1,5 @@
 from tests.integration.class_defs import (
+    ClassWithList,
     OneDefault,
     OneMaybe,
     OneUnspecified,
@@ -21,3 +22,7 @@ def maybe_yes():
 
 def maybe_no():
     return OneMaybe(None)
+
+
+def class_with_list():
+    return ClassWithList(a=[2, 3, 4, 5])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from farconf import obj_to_cli, parse_cli_into_dict, update_fns_to_cli
+from farconf import obj_to_cli, parse_cli, parse_cli_into_dict, update_fns_to_cli
+from farconf.serialize import serialize_class_or_function
 from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
 from tests.integration.instances import class_with_list
 
@@ -83,6 +84,9 @@ def test_update_list_partial():
         obj.a[0] = 5
         obj.a[1] = 2
         return obj
+
+    parsed_obj = parse_cli([f"--from-py-fn={serialize_class_or_function(class_with_list)}", "a=[5, 2]"], ClassWithList)
+    assert parsed_obj == update_fn(class_with_list())
 
     _, cur_obj = update_fns_to_cli(class_with_list, update_fn)
     assert cur_obj == update_fn(class_with_list())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,8 +2,7 @@ import json
 
 import pytest
 
-from farconf import obj_to_cli, parse_cli, parse_cli_into_dict, update_fns_to_cli
-from farconf.serialize import serialize_class_or_function
+from farconf import obj_to_cli, parse_cli_into_dict, update_fns_to_cli
 from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
 from tests.integration.instances import class_with_list
 
@@ -84,9 +83,6 @@ def test_update_list_partial():
         obj.a[0] = 5
         obj.a[1] = 2
         return obj
-
-    parsed_obj = parse_cli([f"--from-py-fn={serialize_class_or_function(class_with_list)}", "a=[5, 2]"], ClassWithList)
-    assert parsed_obj == update_fn(class_with_list())
 
     _, cur_obj = update_fns_to_cli(class_with_list, update_fn)
     assert cur_obj == update_fn(class_with_list())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from farconf import obj_to_cli, parse_cli_into_dict, update_fns_to_cli
+from farconf import config_diff, obj_to_cli, parse_cli_into_dict, update_fns_to_cli
+from farconf.cli import _sequence_is_leaf_if_different
 from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
 from tests.integration.instances import class_with_list
 
@@ -86,3 +87,12 @@ def test_update_list_partial():
 
     _, cur_obj = update_fns_to_cli(class_with_list, update_fn)
     assert cur_obj == update_fn(class_with_list())
+
+
+def _list_of_objects():
+    return [OneDefault(c=SubOneConfig(2)), ClassWithList([4])]
+
+
+def test_update_list_nothing():
+    obj = _list_of_objects()
+    assert config_diff(obj, obj, is_leaf=_sequence_is_leaf_if_different) == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,8 @@ import json
 import pytest
 
 from farconf import obj_to_cli, parse_cli_into_dict, update_fns_to_cli
-from tests.integration.class_defs import OneDefault, SubOneConfig
+from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
+from tests.integration.instances import class_with_list
 
 
 def test_obj_to_cli():
@@ -75,3 +76,13 @@ def test_update_fns_same_obj():
 
     with pytest.raises(ValueError, match="Cannot serialize object <.*> because it is ephemeral"):
         update_fns_to_cli(lambda: OneDefault())
+
+
+def test_update_list_partial():
+    def update_fn(obj: ClassWithList) -> ClassWithList:
+        obj.a[0] = 5
+        obj.a[1] = 2
+        return obj
+
+    _, cur_obj = update_fns_to_cli(class_with_list, update_fn)
+    assert cur_obj == update_fn(class_with_list())


### PR DESCRIPTION
@taufeeque9 reported a bug: changing only some elements of a list in a class with a list results in a correct CLI, but it gets parsed incorrectly.

The CLI produced in this case is correct according to specifications: `['--from-py-fn=tests.integration.instances:class_with_list', 'a=[5, 2]']`. But it produces an incorrect object `{'a': [5, 2]}`.

Solution: always write out the full list when generating a CLI