### PR TITLE
Specify dotlists in a typed way using `typed_dotlist_generator`.

### DIFF
--- a/farconf/__init__.py
+++ b/farconf/__init__.py
@@ -3,6 +3,7 @@ from .cli import (
     obj_to_cli,
     parse_cli,
     parse_cli_into_dict,
+    typed_dotlist,
     update_fns_to_cli,
 )
 from .config_ops import config_diff, config_merge
@@ -15,6 +16,7 @@ __all__ = [
     "parse_cli",
     "parse_cli_into_dict",
     "update_fns_to_cli",
+    "typed_dotlist",
     # config_ops
     "config_diff",
     "config_merge",

--- a/farconf/__init__.py
+++ b/farconf/__init__.py
@@ -3,7 +3,7 @@ from .cli import (
     obj_to_cli,
     parse_cli,
     parse_cli_into_dict,
-    typed_dotlist,
+    typed_dotlist_generator,
     update_fns_to_cli,
 )
 from .config_ops import config_diff, config_merge
@@ -16,7 +16,7 @@ __all__ = [
     "parse_cli",
     "parse_cli_into_dict",
     "update_fns_to_cli",
-    "typed_dotlist",
+    "typed_dotlist_generator",
     # config_ops
     "config_diff",
     "config_merge",

--- a/farconf/cli.py
+++ b/farconf/cli.py
@@ -1,5 +1,6 @@
 """Parse and create command-line arguments
 """
+import dataclasses
 import json
 import re
 from pathlib import Path
@@ -195,20 +196,42 @@ def update_fns_to_cli(
     return cli, cur_obj
 
 
-class _DotlistGenerator:
-    _prefix: str
-
-    def __init__(self, _prefix: str) -> None:
-        self._prefix = _prefix
-
-    def __getattribute__(self, name: str, /) -> Any:
-        prefix = object.__getattribute__(self, "_prefix")
-        return _DotlistGenerator(name if prefix == "" else f"{prefix}.{name}")
-
-    def __str__(self) -> str:
-        return object.__getattribute__(self, "_prefix")
-
-
-def typed_dotlist(obj: DataclassT) -> DataclassT:
+def typed_dotlist(obj: DataclassT, *, _prefix: str = "") -> DataclassT:
     """Create dotlists in a typed way."""
-    return _DotlistGenerator("")  # type: ignore
+    Cls = obj.__class__
+
+    # Create a new dotlist generator class, which is an instance of the same classes `obj` is an instance of. This lets
+    # us assert that attributes are of particular classes, which lets us do typechecking and completion in the IDE.
+    class _DotlistGenerator(Cls):  # type: ignore
+        _obj: Any
+        _prefix: str
+
+        def __init__(self, _obj: Any, _prefix: str) -> None:
+            self._obj = _obj
+            self._prefix = _prefix
+
+        def __getattribute__(self, name: str, /) -> Any:
+            new_obj = getattr(object.__getattribute__(self, "_obj"), name)
+            if name.startswith("__") and name.endswith("__"):
+                # Just return dunder attributes of the _obj
+                return new_obj
+
+            # Add this attribute's name to the prefix
+            prefix = object.__getattribute__(self, "_prefix")
+            new_prefix = name if prefix == "" else f"{prefix}.{name}"
+
+            # Before creating another typed_dotlist, check whether the new object is still a dataclass.  If it is not,
+            # it is pointless to keep track of the prefix anyways, because we shouldn't need to take any more
+            # attributes.
+            #
+            # Besides, `new_obj` might be something like an int: an object which is hard to subclass
+            if not dataclasses.is_dataclass(new_obj):
+                return new_prefix
+
+            assert not isinstance(new_obj, type)
+            return typed_dotlist(new_obj, _prefix=new_prefix)
+
+        def __str__(self) -> str:
+            return object.__getattribute__(self, "_prefix")
+
+    return _DotlistGenerator(obj, _prefix)  # type: ignore

--- a/farconf/cli.py
+++ b/farconf/cli.py
@@ -9,7 +9,7 @@ import yaml
 from databind.json import JsonType
 
 from farconf.config_ops import Atom, config_diff, config_merge
-from farconf.serialize import DataclassT, deserialize_class_or_function, from_dict, serialize_class_or_function, to_dict
+from farconf.serialize import deserialize_class_or_function, from_dict, serialize_class_or_function, to_dict
 
 T = TypeVar("T")
 
@@ -202,12 +202,13 @@ class _DotlistGenerator:
         self._prefix = _prefix
 
     def __getattribute__(self, name: str, /) -> Any:
-        return _DotlistGenerator(name if self._prefix == "" else f"{self.prefix}.{name}")
+        prefix = object.__getattribute__(self, "_prefix")
+        return _DotlistGenerator(name if prefix == "" else f"{prefix}.{name}")
 
     def __str__(self) -> str:
-        return self._prefix
+        return object.__getattribute__(self, "_prefix")
 
 
 def typed_dotlist(obj: DataclassT) -> DataclassT:
     """Create dotlists in a typed way."""
-    return _DotlistGenerator(obj)  # type: ignore
+    return _DotlistGenerator("")  # type: ignore

--- a/farconf/cli.py
+++ b/farconf/cli.py
@@ -9,12 +9,7 @@ import yaml
 from databind.json import JsonType
 
 from farconf.config_ops import Atom, config_diff, config_merge
-from farconf.serialize import (
-    deserialize_class_or_function,
-    from_dict,
-    serialize_class_or_function,
-    to_dict,
-)
+from farconf.serialize import DataclassT, deserialize_class_or_function, from_dict, serialize_class_or_function, to_dict
 
 T = TypeVar("T")
 
@@ -198,3 +193,21 @@ def update_fns_to_cli(
         assert parse_cli_into_dict(cli) == cur_dict
 
     return cli, cur_obj
+
+
+class _DotlistGenerator:
+    _prefix: str
+
+    def __init__(self, _prefix: str) -> None:
+        self._prefix = _prefix
+
+    def __getattribute__(self, name: str, /) -> Any:
+        return _DotlistGenerator(name if self._prefix == "" else f"{self.prefix}.{name}")
+
+    def __str__(self) -> str:
+        return self._prefix
+
+
+def typed_dotlist(obj: DataclassT) -> DataclassT:
+    """Create dotlists in a typed way."""
+    return _DotlistGenerator(obj)  # type: ignore

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,7 @@ def test_update_list_nothing():
 
 def test_typed_dotlist():
     g = typed_dotlist(OneDefault())
+    assert isinstance(g.c, SubOneConfig)
 
     assert str(g) == ""
-    assert str(g.one.two) == "one.two"
+    assert str(g.c.one) == "c.one"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,4 +102,4 @@ def test_typed_dotlist():
     g = typed_dotlist(OneDefault())
 
     assert str(g) == ""
-    assert str(g.one.two) == "g.one.two"
+    assert str(g.one.two) == "one.two"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from farconf import config_diff, obj_to_cli, parse_cli_into_dict, update_fns_to_cli
+from farconf import config_diff, obj_to_cli, parse_cli_into_dict, typed_dotlist, update_fns_to_cli
 from farconf.cli import _sequence_is_leaf_if_different
 from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
 from tests.integration.instances import class_with_list
@@ -96,3 +96,10 @@ def _list_of_objects():
 def test_update_list_nothing():
     obj = _list_of_objects()
     assert config_diff(obj, obj, is_leaf=_sequence_is_leaf_if_different) == []
+
+
+def test_typed_dotlist():
+    g = typed_dotlist(OneDefault())
+
+    assert str(g) == ""
+    assert str(g.one.two) == "g.one.two"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from farconf import config_diff, obj_to_cli, parse_cli_into_dict, typed_dotlist, update_fns_to_cli
+from farconf import config_diff, obj_to_cli, parse_cli_into_dict, typed_dotlist_generator, update_fns_to_cli
 from farconf.cli import _sequence_is_leaf_if_different
 from tests.integration.class_defs import ClassWithList, OneDefault, SubOneConfig
 from tests.integration.instances import class_with_list
@@ -98,8 +98,8 @@ def test_update_list_nothing():
     assert config_diff(obj, obj, is_leaf=_sequence_is_leaf_if_different) == []
 
 
-def test_typed_dotlist():
-    g = typed_dotlist(OneDefault())
+def test_typed_dotlist_generator():
+    g = typed_dotlist_generator(OneDefault())
     assert isinstance(g.c, SubOneConfig)
 
     assert str(g) == ""


### PR DESCRIPTION
The purpose of this new function is to let you specify dotlists like this:

```python
g = typed_dotlist_generator(obj)
dotlist = {
    g.something.b.c.f: 2,
    g.other.thing: "hello"
}
{str(k): v for k, v in dotlist.items()} == {"something.b.c.f": 2, "other.thing": "hello"}
```
This lets you use the IDE's completion to specify updates to the base object `obj`. Additionally, refactoring `obj`
will keep all your old experiment specifications working.
